### PR TITLE
Enhance movie preplay page and use image transcoder for posters

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -34,6 +34,7 @@ except ImportError:
 import time, uuid, hmac, hashlib, base64
 from urllib import urlencode
 from urlparse import urlparse
+from urllib import quote_plus
 
 import Settings
 from Debug import *  # dprint()
@@ -195,6 +196,9 @@ def XML_PMS2aTV(address, path):
         if indirect=='1':  # redirect... todo: select suitable resolution, today we just take first Media
             PMS = XML_ReadFromURL(address, key)  # todo... check key for trailing '/' or even 'http'
             PMSroot = PMS.getroot()
+
+    elif cmd=='MoviePreview':
+        XMLtemplate = 'MoviePreview.xml'
     
     elif cmd=='MoviePrePlay':
         XMLtemplate = 'MoviePrePlay.xml'
@@ -668,7 +672,28 @@ class CCommandCollection(CCommandHelper):
         else:
             res = self.path[srcXML]+'/'+addpath
         return res
+
+    def ATTRIB_BIGIMAGEURL(self, src, srcXML, param):
+        key, leftover, dfltd = self.getKey(src, srcXML, param)
+        return self.imageUrl(self.path[srcXML], key, 512, 512)
     
+    def ATTRIB_IMAGEURL(self, src, srcXML, param):
+        key, leftover, dfltd = self.getKey(src, srcXML, param)
+        return self.imageUrl(self.path[srcXML], key, 384, 384)
+            
+    def imageUrl(self, path, key, width, height):
+        if key.startswith('/'):  # internal full path.
+            res = 'http://127.0.0.1:32400' + key
+        elif key.startswith('http://'):  # external address
+            res = key
+        else:
+            res = 'http://127.0.0.1:32000' + path + '/' + key
+        
+        # This is bogus (note the extra path component) but ATV is stupid when it comes to caching images, it doesn't use querystrings.
+        # Fortunately PMS is lenient...
+        #
+        return 'http://' + g_param['Addr_PMS'] + '/photo/:/transcode/%s/?width=%d&height=%d&url=' % (quote_plus(res), width, height) + quote_plus(res)
+            
     def ATTRIB_URL(self, src, srcXML, param):
         key, leftover, dfltd = self.getKey(src, srcXML, param)
         if key.startswith('/'):  # internal full path.
@@ -733,6 +758,16 @@ class CCommandCollection(CCommandHelper):
     
     def ATTRIB_getPath(self, src, srcXML, param):
         return self.path[srcXML] 
+    
+    def ATTRIB_getDurationString(self, src, srcXML, param):
+        duration, leftover, dfltd = self.getKey(src, srcXML, param)
+        if len(duration) > 0:
+            min = int(duration)/1000/60
+            hour = min/60
+            min = min%60
+            return "%dhr %dm" % (hour, min)            
+            
+        return ""
     
     def ATTRIB_getResString(self, src, srcXML, param):
         res, leftover, dfltd = self.getKey(src, srcXML, param) # getKey "defaults" if nothing found.

--- a/assets/templates/ByFolderPreview.xml
+++ b/assets/templates/ByFolderPreview.xml
@@ -11,7 +11,7 @@
               {{COPY(Video)}}
               <title>{{VAL(title)}}</title>
               <subtitle>{{VAL(year)}}</subtitle>
-              <image>{{URL(thumb)}}</image>
+              <image>{{IMAGEURL(thumb)}}</image>
               <defaultImage>resource://16X9.png</defaultImage>
             </sixteenByNinePoster>
           </items>

--- a/assets/templates/ChannelPrePlay.xml
+++ b/assets/templates/ChannelPrePlay.xml
@@ -5,7 +5,7 @@
 		<subtitle>{{VAL(Video/studio)}}</subtitle>
 		<rating>{{VAL(Video/contentRating)}}</rating>
 		<summary>{{VAL(Video/summary)}}</summary>
-		<image style="squarePoster">{{URL(Video/thumb)}}</image>
+		<image style="squarePoster">{{IMAGEURL(Video/thumb)}}</image>
 		<defaultImage>resource://Poster.png</defaultImage>
     		
 		<centerShelf>

--- a/assets/templates/Channels.xml
+++ b/assets/templates/Channels.xml
@@ -29,10 +29,10 @@
                                        onSelect="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}&amp;PlexConnect=ChannelsVideo')">
                 {{COPY(@VideoChannels/Directory)}}
                 <label>{{VAL(title)}}</label>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>
@@ -52,10 +52,10 @@
                                        onSelect="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}')">
                 {{COPY(@AudioChannels/Directory)}}
                 <label>{{VAL(title)}}</label>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>
@@ -75,10 +75,10 @@
                                        onSelect="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}')">
                 {{COPY(@PhotoChannels/Directory)}}
                 <label>{{VAL(title)}}</label>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>

--- a/assets/templates/ChannelsVideo.xml
+++ b/assets/templates/ChannelsVideo.xml
@@ -17,13 +17,13 @@
                                        onSelect="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}&amp;PlexConnect=ChannelPrePlay')">
                 {{COPY(Video)}}
                 <label>{{VAL(title)}}</label>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <!--<defaultImage>resource://Poster.png</defaultImage>-->
                 <preview>
                   <keyedPreview>
                     <title>{{VAL(title)}}</title>
                     <summary>{{VAL(summary)}}</summary>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </keyedPreview>
                 </preview>
               </twoLineEnhancedMenuItem>
@@ -36,12 +36,12 @@
                 <!--
                 <rightLabel>another 100 files...</rightLabel>
                 -->
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <!--<image>http://trailers.apple.com/thumbnails/DirectoryLink.jpg</image>-->
                 <!--<defaultImage>resource://Poster.png</defaultImage>-->
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>

--- a/assets/templates/Directory.xml
+++ b/assets/templates/Directory.xml
@@ -20,12 +20,12 @@
                 <!--
                 <rightLabel>another 100 files...</rightLabel>
                 -->
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <!--<image>http://trailers.apple.com/thumbnails/DirectoryLink.jpg</image>-->
                 <defaultImage>resource://Poster.png</defaultImage>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </oneLineMenuItem>

--- a/assets/templates/Episode.xml
+++ b/assets/templates/Episode.xml
@@ -24,7 +24,7 @@
                 <label>{{VAL(title)}}</label>
                 <ordinal>{{VAL(index)}}</ordinal>
                 <maxOrdinalDigits>2</maxOrdinalDigits>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <!--<defaultImage>resource://16X9.png</defaultImage>      This causes the thumbnail to be too small, not sure why.-->
                 <accessories>
                   <unplayedDot/>{{CUT(viewCount)}}
@@ -33,7 +33,7 @@
                   <keyedPreview>
                     <title>{{VAL(title)}}</title>
                     <summary>{{VAL(summary)}}</summary>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{IMAGEURL(thumb)}}</image>
                   </keyedPreview>
                 </preview>
               </twoLineEnhancedMenuItem>{{CUT(Video/title:CUT:=)}}

--- a/assets/templates/MoviePrePlay.xml
+++ b/assets/templates/MoviePrePlay.xml
@@ -1,11 +1,11 @@
 <atv>
   <body>
     <itemDetail id="com.apple.trailer">
-      <title>{{VAL(Video/title)}}</title>
+      <title>{{VAL(Video/title)}} ({{VAL(Video/year)}})</title>
       <subtitle>{{VAL(Video/studio)}}</subtitle>
       <rating>{{VAL(Video/contentRating)}}</rating>
       <summary>{{VAL(Video/summary)}}</summary>
-      <image style="moviePoster">{{URL(Video/thumb)}}</image>
+      <image style="moviePoster">{{BIGIMAGEURL(Video/thumb)}}</image>
       <defaultImage>resource://Poster.png</defaultImage>
  		
       <table>
@@ -13,19 +13,45 @@
           <columnDefinition width="25" alignment="left">
             <title>Details</title>
           </columnDefinition>
+          <columnDefinition width="25" alignment="left">
+            <title>Actors</title>
+          </columnDefinition>
+          <columnDefinition width="25" alignment="left">
+            <title>Directors</title>
+          </columnDefinition>
+          <columnDefinition width="25" alignment="left">
+            <title>Producers</title>
+          </columnDefinition>
         </columnDefinitions>
         <rows>
           <row>
-            <label>{{VAL(Video/Genre/tag)}}</label>	
+            <label>{{VAL(Video/Genre/tag)}}</label>
+            <label>{{VAL(Video/Role/tag)}}</label>
+            <label>{{VAL(Video/Director/tag)}}</label>
+            <label>{{VAL(Video/Producer/tag)}}</label>
+          </row>
+          <row>
+            <label>{{getDurationString(Video/duration)}}</label>
+            <label>{{VAL(Video/Role[2]/tag)}}</label>
+            <label>{{VAL(Video/Director[2]/tag)}}</label>
+            <label>{{VAL(Video/Producer[2]/tag)}}</label>
           </row>
           <row>
             <label>{{getResString(Video/Media/videoResolution)}}</label>
+            <label>{{VAL(Video/Role[3]/tag)}}</label>
+            <label>{{VAL(Video/Director[3]/tag)}}</label>
+            <label>{{VAL(Video/Producer[3]/tag)}}</label>
+          </row>
+          <row>
+            <label/>
+            <label>{{VAL(Video/Role[4]/tag)}}</label>
+            <label>{{VAL(Video/Director[4]/tag)}}</label>
+            <label>{{VAL(Video/Producer[4]/tag)}}</label>            
           </row>
           <row>
             <starRating>
               <percentage>{{EVAL(Video/rating:0:int(x*10))}}</percentage>
-            </starRating>{{CUT(Video/rating:CUT:=)}}
-            <label></label>{{CUT(Video/rating::=CUT)}}
+            </starRating>
           </row>
         </rows>
       </table>
@@ -41,12 +67,19 @@
                   <focusedImage>resource://PlayFocused.png</focusedImage>
                   <!--<badge></badge>-->
                 </actionButton>
+                
+                <actionButton id="more" accessibilityLabel="More info" onSelect="atv.showMoreInfo();">
+                  <title>More</title>
+                  <image>resource://More.png</image>
+                  <focusedImage>resource://MoreFocused.png</focusedImage>
+                </actionButton>
               </items>
             </shelfSection>
           </sections>
         </shelf>
       </centerShelf>
     
+      <!--
       <divider>
         <smallCollectionDivider alignment="left">
           <title>Actors</title>
@@ -62,15 +95,77 @@
                   {{COPY(Video/Role)}}
                   <title>{{VAL(tag)}}</title>
                   <subtitle>as {{VAL(role)}}</subtitle>
-                  <image>{{VAL(thumb)}}</image>
+                  <image>{{IMAGEURL(thumb)}}</image>
                   <defaultImage>http://{{ADDR_PMS()}}/:/resources/actor-icon.png</defaultImage>
                 </moviePoster>
               </items>
             </shelfSection>
           </sections>
         </shelf>
-      </bottomShelf>{{CUT(Video/Role/id:CUT:=)}}      
-       
+      </bottomShelf>{{CUT(Video/Role/id:CUT:=)}}
+      -->
+      
+      <moreInfo>
+        <listScrollerSplit id="com.sample.list-scroller-split">
+          <menu>
+            <sections>
+              <menuSection>
+                <header>
+                  <textDivider alignment="left" accessibilityLabel="Genres">
+                    <title>Genres</title>
+                  </textDivider>
+                </header>
+                <items>
+                  <oneLineMenuItem id="list_2">
+                    {{COPY(Video/Genre)}}
+                    <label>{{VAL(tag)}}</label>
+                    <preview>
+                      <link>http://trailers.apple.com/library/sections/{{VAL(/librarySectionID)}}/genre/{{VAL(id)}}?X-Plex-Container-Start=0&amp;X-Plex-Container-Size=50&amp;PlexConnect=MoviePreview</link>
+                    </preview>
+                  </oneLineMenuItem>
+                </items>
+              </menuSection>
+              
+              <menuSection>
+                <header>
+                  <textDivider alignment="left" accessibilityLabel="Directors">
+                    <title>Directors</title>
+                  </textDivider>
+                </header>
+                <items>
+                  <oneLineMenuItem id="list_3" accessibilityLabel="Ivan Reitman">
+                    {{COPY(Video/Director)}}
+                    <label>{{VAL(tag)}}</label>
+                    <preview>
+                      <link>http://trailers.apple.com/library/sections/{{VAL(/librarySectionID)}}/director/{{VAL(id)}}/&amp;PlexConnect=MoviePreview</link>
+                    </preview>
+                  </oneLineMenuItem>
+                </items>
+              </menuSection>
+              
+              <menuSection>
+                <header>
+                  <textDivider alignment="left" accessibilityLabel="Actors">
+                    <title>Actors</title>
+                  </textDivider>
+                </header>
+                <items>
+                  <twoLineMenuItem id="list_0" accessibilityLabel="Natalie Portman">
+                    {{COPY(Video/Role)}}
+                    <label>{{VAL(tag)}}</label>
+                    <label2>{{VAL(role)}}</label2>
+                    <preview>
+                      <link>http://trailers.apple.com/library/sections/{{VAL(/librarySectionID)}}/actor/{{VAL(id)}}/&amp;PlexConnect=MoviePreview</link>
+                    </preview>
+                  </twoLineMenuItem>
+                </items>
+              </menuSection>
+              
+            </sections>
+          </menu>
+        </listScrollerSplit>
+      </moreInfo>
+      
 		</itemDetail>
 	</body>
 </atv>

--- a/assets/templates/MoviePreview.xml
+++ b/assets/templates/MoviePreview.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atv>
+  <body>
+    <preview>
+      <scrollerPreview id="com.sample.moreInfoPreview">
+        <header>
+          <metadataHeader>
+            <title>{{VAL(title2)}}</title>
+            <subtitle>{{VAL(size)}} Movies</subtitle>
+          </metadataHeader>
+        </header>
+        <items>
+          <grid id="grid_0" columnCount="5">
+            <items>
+              <moviePoster id="{{VAL(key)}}"
+                           onSelect="atv.sessionStorage['addrpms']='{{ADDR_PMS()}}';{{sendToATV(ratingKey:0:duration:0)}};atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}&amp;PlexConnect=MoviePrePlay')"
+                           onPlay="atv.sessionStorage['addrpms']='{{ADDR_PMS()}}';{{sendToATV(ratingKey:0:duration:0)}};atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}{{PLAY_COMMAND()}})">
+                {{COPY(Video)}}
+                <title>{{VAL(title)}}</title>
+                <subtitle>{{VAL(year)}}</subtitle>
+                <image>{{IMAGEURL(thumb)}}</image>
+                <defaultImage>resource://16X9.png</defaultImage>
+              </moviePoster>
+            </items>
+          </grid>
+        </items>
+      </scrollerPreview>
+    </preview>
+  </body>
+</atv>

--- a/assets/templates/Movie_Grid.xml
+++ b/assets/templates/Movie_Grid.xml
@@ -22,7 +22,7 @@
               {{COPY(Video)}}
               <title>{{VAL(title)}}</title>
               <subtitle>{{VAL(year)}}</subtitle>
-              <image>{{URL(thumb)}}</image>
+              <image>{{IMAGEURL(thumb)}}</image>
               <defaultImage>resource://Poster.png</defaultImage>
             </moviePoster>
           </items>

--- a/assets/templates/Movie_List.xml
+++ b/assets/templates/Movie_List.xml
@@ -25,7 +25,7 @@
                 <label>{{VAL(title)}}</label>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{IMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </oneLineMenuItem>{{CUT(Video/title:CUT:=)}}

--- a/assets/templates/PlayVideo.xml
+++ b/assets/templates/PlayVideo.xml
@@ -6,7 +6,7 @@
         <title>{{VAL(Video/title)}}</title>
         <description>{{VAL(Video/summary)}}</description>
         <bookmarkTime>{{EVAL(Video/viewOffset:0:int(x/1000))}}</bookmarkTime>
-        <image>{{URL(Video/thumb)}}</image>
+        <image>{{IMAGEURL(Video/thumb)}}</image>
       </httpFileVideoAsset>
     </videoPlayer>
   </body>

--- a/assets/templates/Season.xml
+++ b/assets/templates/Season.xml
@@ -21,11 +21,11 @@
                 {{COPY(Directory)}}
                 <label>{{VAL(title)}}</label>
                 <rightLabel>{{VAL(leafCount)}} Episodes</rightLabel>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <defaultImage>resource://Poster.png</defaultImage>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>{{CUT(Directory/title:CUT:=)}}

--- a/assets/templates/Season_Coverflow.xml
+++ b/assets/templates/Season_Coverflow.xml
@@ -24,7 +24,7 @@
                                               onHoldSelect="scrobbleMenu('Season', '{{VAL(ratingKey)}}', '{{ADDR_PMS()}}');">
                   {{COPY(Directory)}}
                   <title>{{VAL(title)}}</title>
-                  <image>{{URL(thumb)}}</image>
+                  <image>{{IMAGEURL(thumb)}}</image>
                   <defaultImage>resource://Poster.png</defaultImage>
                 </goldenPoster>{{CUT(Directory/title:CUT:=)}}
             

--- a/assets/templates/Season_List.xml
+++ b/assets/templates/Season_List.xml
@@ -21,11 +21,11 @@
                 {{COPY(Directory)}}
                 <label>{{VAL(title)}}</label>
                 <rightLabel>{{VAL(leafCount)}} Episodes</rightLabel>
-                <image>{{URL(thumb)}}</image>
+                <image>{{IMAGEURL(thumb)}}</image>
                 <defaultImage>resource://Poster.png</defaultImage>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </twoLineEnhancedMenuItem>{{CUT(Directory/title:CUT:=)}}

--- a/assets/templates/Show_Grid.xml
+++ b/assets/templates/Show_Grid.xml
@@ -21,7 +21,7 @@
                          onHoldSelect="scrobbleMenu('Show', '{{VAL(ratingKey)}}', '{{ADDR_PMS()}}');">
               {{COPY(Directory)}}
               <title>{{VAL(title)}}</title>
-              <image>{{URL(thumb)}}</image>
+              <image>{{IMAGEURL(thumb)}}</image>
               <defaultImage>resource://Poster.png</defaultImage>
             </moviePoster>{{CUT(Directory/title:CUT:=)}}
           

--- a/assets/templates/Show_List.xml
+++ b/assets/templates/Show_List.xml
@@ -23,7 +23,7 @@
                 <label>{{VAL(title)}}</label>
                 <preview>
                   <crossFadePreview>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </crossFadePreview>
                 </preview>
               </oneLineMenuItem>{{CUT(Directory/title:CUT:=)}}

--- a/assets/templates/TV_OnDeck.xml
+++ b/assets/templates/TV_OnDeck.xml
@@ -21,13 +21,13 @@
                 {{COPY(Video)}}
                 <label>{{VAL(grandparentTitle)}}</label>
                 <label2>{{episodestring(parentIndex:0:index:0:title:"default")}}</label2>
-                <image>{{URL(grandparentThumb)}}</image>
+                <image>{{IMAGEURL(grandparentThumb)}}</image>
                 <defaultImage>resource://Poster.png</defaultImage>
                 <preview>
                   <keyedPreview>
                     <title>{{VAL(title)}}</title>
                     <summary>{{VAL(summary)}}</summary>
-                    <image>{{URL(thumb)}}</image>
+                    <image>{{BIGIMAGEURL(thumb)}}</image>
                   </keyedPreview>
                 </preview>
               </twoLineEnhancedMenuItem>


### PR DESCRIPTION
This adds lots of enhancements to the pre-play page, and adds the
ability to pivot via More on genre, directors, and actors. Posters are
now transcoded, which makes browsing much faster.
