### PR TITLE
Added audio codec and channel information to movie pre-play screen.

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -780,6 +780,21 @@ class CCommandCollection(CCommandHelper):
         elif res=='480': return 'SD'
         elif res=='sd': return 'SD'
         return 'Unknown: ' + res
+
+    def ATTRIB_getAudioChannelsString(self, src, srcXML, param):
+        audiochannels, leftover, dfltd = self.getKey(src, srcXML, param)
+        if audiochannels=='6': return '5.1'
+        elif audiochannels=='8': return '7.1'
+        elif audiochannels=='2': return '2.0'
+        return 'Unknown: ' + audiochannels
+
+    def ATTRIB_getAudioChannelCodecString(self, src, srcXML, param):
+        audiochannelcodec, leftover, dfltd = self.getKey(src, srcXML, param)
+        if audiochannelcodec=='ac3': return 'AC3'
+        elif audiochannelcodec=='mp3': return 'MP3'
+        elif audiochannelcodec=='aac': return 'AAC'
+        elif audiochannelcodec=='dca': return 'DTS'
+        return 'Unknown'
      
      
 if __name__=="__main__":

--- a/assets/templates/MoviePrePlay.xml
+++ b/assets/templates/MoviePrePlay.xml
@@ -43,7 +43,7 @@
             <label>{{VAL(Video/Producer[3]/tag)}}</label>
           </row>
           <row>
-            <label/>
+            <label>{{getAudioChannelsString(Video/Media/audioChannels)}} {{getAudioChannelCodecString(Video/Media/audioCodec)}}</label>
             <label>{{VAL(Video/Role[4]/tag)}}</label>
             <label>{{VAL(Video/Director[4]/tag)}}</label>
             <label>{{VAL(Video/Producer[4]/tag)}}</label>            


### PR DESCRIPTION
Hey Guys,

I added some functions to XMLConverter.py to allow the display of both the number of audio channels and the codec they are stored in.  Also changed the MoviePrePlay.xml template to add these attributes.

Fiddled with doing the same for TV episodes but since I am grasping at straws in Python/XML I found myself at a loss.

`cc
