### PR TITLE
Add animated previews in section list.

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -238,8 +238,13 @@ def XML_PMS2aTV(address, path):
         g_ATVSettings.toggleSetting(UDID, opt.lower())
         dprint(__name__, 2, "ATVSettings->Toggle: {0}", opt)
         
-    elif PMSroot.get('viewGroup') is None or \
-       PMSroot.get('viewGroup')=='secondary':
+    elif PMSroot.get('viewGroup') is None:
+        XMLtemplate = 'Sections.xml'
+
+    elif cmd == 'SectionPreview':
+        XMLtemplate = 'SectionPreview.xml'
+
+    elif PMSroot.get('viewGroup')=='secondary':
         XMLtemplate = 'Directory.xml'
         
     elif PMSroot.get('viewGroup')=='show':

--- a/assets/templates/SectionPreview.xml
+++ b/assets/templates/SectionPreview.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atv>
+  <body>
+     <preview>
+        <paradePreview inOrder="true">
+          <image>
+            {{COPY(Video)}}
+            {{BIGIMAGEURL(thumb)}}
+          </image>
+          <image>
+            {{COPY(Directory)}}
+            {{BIGIMAGEURL(thumb)}}
+          </image>
+          <image>
+            {{COPY(Photo)}}
+            {{BIGIMAGEURL(thumb)}}
+          </image>
+        </paradePreview>
+      </preview>
+  </body>
+</atv>

--- a/assets/templates/Sections.xml
+++ b/assets/templates/Sections.xml
@@ -1,0 +1,30 @@
+<atv>
+  <body>
+    <listWithPreview id="com.sample.menu-items-with-sections">
+      <header>
+        <simpleHeader>
+          <title>{{VAL(title1:Plex Library)}}</title>
+          <subtitle>{{VAL(title2)}}</subtitle>
+        </simpleHeader>
+      </header>
+      <menu>
+        <sections>
+          <menuSection>
+            <items>
+              <!-- library directories -->
+              <oneLineMenuItem id="{{VAL(key)}}" 
+                                       onPlay="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}')" 
+                                       onSelect="atv.loadURL('http://trailers.apple.com{{ADDPATH(key)}}')">
+                {{COPY(Directory)}}
+                <label>{{VAL(title)}}</label>
+                <preview>
+                  <link>http://trailers.apple.com{{ADDPATH(key)}}/recentlyAdded?stack=1&amp;X-Plex-Container-Start=0&amp;X-Plex-Container-Size=25&amp;PlexConnect=SectionPreview</link>
+                </preview>
+              </oneLineMenuItem>
+            </items>
+          </menuSection>
+        </sections>
+      </menu>
+    </listWithPreview>
+  </body>
+</atv>


### PR DESCRIPTION
Adds the nice animated previews that are common in such lists.

![img_3472](https://f.cloud.github.com/assets/10298/595674/f19ee202-cb1c-11e2-9e5c-65acbe1e9319.jpg)
