### PR TITLE
Added X-Plex headers to aid with channel compatibility

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -599,6 +599,7 @@ def PlexAPI_getXArgs():
     xargs['X-Plex-Platform'] = 'iOS'
     xargs['X-Plex-Product'] = 'Plex Connect'
     xargs['X-Plex-Platform-Version'] = '5.3' # Base it on AppleTV.
+    xargs['X-Plex-Client-Capabilities'] = "protocols=http-live-streaming,http-mp4-streaming,http-streaming-video,http-streaming-video-720p,http-mp4-video,http-mp4-video-720p;videoDecoders=h264{profile:high&resolution:1080&level:41};audioDecoders=mp3,aac{bitrate:160000}"
     
     return xargs
 


### PR DESCRIPTION
Including a version number (in this case "1.0") will allow @jam to add framework support for PlexConnect to receive transcoded RTMP streams.
Advertising client capabilities equal to iOS client should allow any channel which shows up on iOS to show up on PlexConnect without using "Disable Capability Checking".
