### PR TITLE
Correct XMLConverter.py to restore 5.1 audio

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -598,6 +598,7 @@ def PlexAPI_getXArgs():
     xargs['X-Plex-Model'] = '3,1' # Base it on AppleTV model.
     xargs['X-Plex-Device-Name'] = 'MyAppleTV' # "friendly" name. Base on UDID? Add UDID?
     xargs['X-Plex-Platform'] = 'iOS'
+    xargs['X-Plex-Client-Platform'] = 'iOS'
     xargs['X-Plex-Platform-Version'] = '5.3' # Base it on AppleTV OS version.
     xargs['X-Plex-Product'] = 'PlexConnect'
     xargs['X-Plex-Version'] = '0.2'


### PR DESCRIPTION
As of commit (655befe3bfcecb8acbf220b6527131d1f17544fb) the Plex Client Platform attribute was removed.  This is one of the attributes used by PMS to identify the Apple TV and its capabilities.  Without it, only stereo audio will be sent to the Apple TV.
