### PR TITLE
Add entry in Settings.cfg to specify a IP address (temp fix of #84 & #87)

### DIFF
--- a/PlexConnect.py
+++ b/PlexConnect.py
@@ -57,12 +57,12 @@ def startup():
     dinit('PlexConnect', param, True)  # init logging, new file, main process
     
     # more Settings        
-    if cfg.getSetting('ip_plexconnect').startswith('xxx.'):
-        # get public ip of local machine
+    if cfg.getSetting('enable_autodetect_ip_dnslocal')=='True':
+        # get public ip of local machine for DNS
         param['IP_self'] = getIP_self()
     else:
-        # If IP for PlexConnect DNS Server is specified in Settings use it
-        IP = cfg.getSetting('ip_plexconnect')
+        # Otherwise use ip_dnslocal from Settings.cfg
+        IP = cfg.getSetting('ip_dnslocal')
         param['IP_self'] = IP
         dprint('PlexConnect', 0, "IP_self: "+IP)
 

--- a/Settings.py
+++ b/Settings.py
@@ -12,9 +12,10 @@ from Debug import *  # dprint()
 Global Settings...
 PMS: plexgdm, ip_pms, port_pms
 DNS:    ip_dnsmaster - IP of Router, ISP's DNS, ... [dflt: google public DNS]
-        ip_plexconnect -    Force IP of local machine of PlexConnect DNS Server (useful if you run VPN,
-                                or have more than one Network Interface running,
-                                or other ip detect errors
+        enable_autodetect_ip_dnslocal - True = Plex connect automatically attempts to get local machine IP
+                                        False = You must enter an IP in the settings field ip_dnslocal
+        ip_dnslocal -    If enable_autodetect_ip_dnslocal is False, this IP will be used for PlexConnect DNS Server
+                         (useful if you run VPN, or have more than one Network Interface running,or other ip detect errors
 HTTP: ip_httpforward, port_httpforward
 """
 g_settings = { \
@@ -24,7 +25,8 @@ g_settings = { \
     \
     'enable_dnsserver':('True', 'False'), \
     'ip_dnsmaster'    :('8.8.8.8',), \
-    'ip_plexconnect'  :('xxx.xxx.xxx.xxx',), \
+    'enable_autodetect_ip_dnslocal'  :('True','False'), \
+    'ip_dnslocal':('192.168.0.1',), \
     \
     'ip_webserver'    :('0.0.0.0',), \
     'port_webserver'  :('80',), \


### PR DESCRIPTION
To temporarily Address the IP address issue for VPN Users, I added an Entry to Settings.cfg to specify an IP address for the PlexConnect DNS Server to be used for intercepting the Trailers Call from ATV. THe default is 'xxx.xxx.xxx.xxx' and can be changed to any IPv4 address. This address should match the IP address entered into the ATV DNS address field.

With the second commit I attempted to implement iBaa's suggestions for and enable/disable autodetect IP setting instead of relying on the xxx.xxx.xxx.xxx default, and to make the names of the settings more intuitive.
