### PR TITLE
SSL Fix for Latest ATV Update

### DIFF
--- a/WebServer.py
+++ b/WebServer.py
@@ -206,6 +206,7 @@ def Run(cmdPipe, param):
                 cmd = cmdPipe.recv()
                 if cmd=='shutdown':
                     break
+            time.sleep(1)
     
     except KeyboardInterrupt:
         signal.signal(signal.SIGINT, signal.SIG_IGN)  # we heard you!


### PR DESCRIPTION
This patch adds SSL support to the WebServer. This is a necessary but not sufficient component of getting PlexConnect working again with the latest app updates on the ATV. The user must also generate and import a root certificate onto their ATV using the Apple Configurator tool (currently OS X only). Instructions are documented here: https://langui.sh/2013/08/27/appletv-ssl-plexconnect/

This PR should probably not be merged yet as it needs an update to the Settings.py to add the two new Settings.cfg requirements (port_ssl and certfile). It could also easily be updated to generate the certificate automatically for the user (although the creation of a profile and installation on the ATV must remain manual)
