### PR TITLE
Add a setting to specify the DNS server port

### DIFF
--- a/DNSServer.py
+++ b/DNSServer.py
@@ -319,13 +319,14 @@ def Run(cmdPipe, param):
     
     cfg_IP_self = param['IP_self']
     cfg_IP_DNSMaster = param['CSettings'].getSetting('ip_dnsmaster')
+    cfg_Port_DNS_Server = param['CSettings'].getSetting('port_dns_server')
     
     try:
         DNS = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         DNS.settimeout(5.0)
-        DNS.bind(('',53))
+        DNS.bind(('',int(cfg_Port_DNS_Server)))
     except Exception, e:
-        dprint(__name__, 0, "Failed to create socket on UDP port 53: {0}", e)
+        dprint(__name__, 0, "Failed to create socket on UDP port {0}: {1}", cfg_Port_DNS_Server, e)
         sys.exit(1)
     
     try:

--- a/Settings.py
+++ b/Settings.py
@@ -31,6 +31,7 @@ g_settings = { \
     'ip_webserver'    :('0.0.0.0',), \
     'port_webserver'  :('80',), \
     'port_ssl'        :('443',), \
+    'port_dns_server' :('53',), \
     'certfile'        :('./assets/certificates/trailers.pem',), \
     \
     'loglevel'        :('Normal', 'High'), \


### PR DESCRIPTION
To allow users to specify an alternate port for the DNS server. This will allow PlexConnect to run as a non-root user and also to accommodate other DNS servers on the system. Users will have to use iptables to redirect UDP 53 from the Apple TV to the appropriate port.
