### PR TITLE
Bind DNS Server to our cfg_IP_self

### DIFF
--- a/DNSServer.py
+++ b/DNSServer.py
@@ -324,7 +324,7 @@ def Run(cmdPipe, param):
     try:
         DNS = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         DNS.settimeout(5.0)
-        DNS.bind(('',int(cfg_Port_DNSServer)))
+        DNS.bind((cfg_IP_self,int(cfg_Port_DNSServer)))
     except Exception, e:
         dprint(__name__, 0, "Failed to create socket on UDP port {0}: {1}", cfg_Port_DNSServer, e)
         sys.exit(1)
@@ -332,7 +332,7 @@ def Run(cmdPipe, param):
     try:
         DNS_forward = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         DNS_forward.settimeout(5.0)
-        DNS_forward.bind(('', 0))  # 0 -> next free public port
+        DNS_forward.bind((cfg_IP_self, 0))  # 0 -> next free public port
         # todo: do we need bind?
     except Exception, e:
         dprint(__name__, 0, "Failed to create socket on UDP port 49152: {0}", e)


### PR DESCRIPTION
This fixes an issue where multiple DNS servers on the same box but on different IPs wont' work. Plex tries to bind it's DNS server to ALL IPs, when it should just bind to cfg_IP_self.
