### PR TITLE
fix typo for params, should be param in line 1016

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1013,7 +1013,7 @@ class CCommandCollection(CCommandHelper):
                 res = Video.get('key','')
                 res = PlexAPI_getTranscodePath(self.options, res)
         else:
-            dprint(__name__, 0, "MEDIAPATH - element not found: {0}", params)
+            dprint(__name__, 0, "MEDIAPATH - element not found: {0}", param)
             res = 'FILE_NOT_FOUND'  # not found?
         
         if res.startswith('/'):  # internal full path.


### PR DESCRIPTION
My IDE gives a syntax error that params is not defined in  XMLConverter.py line 1016

105 else:
106           dprint(**name**, 0, "MEDIAPATH - element not found: {0}", params)
107            res = 'FILE_NOT_FOUND'  # not found?

I checked, looks like should be 'param'? Seem barely fall in this path though, kind of typo? Anway, please check and merge if needed.
