### PR TITLE
Update PlexConnect.py by adding time.sleep (20) to delay PlexConnect 20 ...

### DIFF
--- a/PlexConnect.py
+++ b/PlexConnect.py
@@ -7,7 +7,8 @@ Sources:
 inter-process-communication (queue): http://pymotw.com/2/multiprocessing/communication.html
 """
 
-
+import time
+time.sleep (20)
 import sys, time
 from os import sep
 import socket


### PR DESCRIPTION
Update PlexConnect.py by adding time.sleep (20) to delay PlexConnect 20 seconds to give PMS a chance to load.

I'd prefer to see this an entry  in Settings.py to let people choose to enable it or not to a time period of their chosen, but the ability to do this escapes me.

Idea stolen from: http://forums.plexapp.com/index.php/topic/82906-preliminary-instructions-to-run-daemon-on-osx/?p=478142

credits to siaccarino
