### PR TITLE
Added support for utf-encoded image paths

### DIFF
--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -621,7 +621,7 @@ def getTranscodeImagePath(key, AuthToken, path, width, height):
     
     # This is bogus (note the extra path component) but ATV is stupid when it comes to caching images, it doesn't use querystrings.
     # Fortunately PMS is lenient...
-    path = '/photo/:/transcode/%s/?width=%s&height=%s&url=' % (quote_plus(path), width, height) + quote_plus(path)
+    path = '/photo/:/transcode/%s/?width=%s&height=%s&url=' % (quote_plus(path.encode('utf8')), width, height) + quote_plus(path.encode('utf8'))
     
     if not AuthToken=='':
         xargs = dict()


### PR DESCRIPTION
Running PlexConnect and browsing my swedish channels, e.g. SVT Play, rendered the following error in the log:

12:29:57 XMLConverter: XML_ExpandLine - Error in {{IMAGEURL(thumb::384)}}
Traceback (most recent call last):
  File "/Users/mattias/projects/sources/PlexConnect/XMLConverter.py", line 561, in XML_ExpandLine
    res = getattr(g_CommandCollection, 'ATTRIB_'+cmd)(src, srcXML, param)
  File "/Users/mattias/projects/sources/PlexConnect/XMLConverter.py", line 909, in ATTRIB_IMAGEURL
    res = PlexAPI.getTranscodeImagePath(key, AuthToken, self.path[srcXML], width, height)
  File "/Users/mattias/projects/sources/PlexConnect/PlexAPI.py", line 624, in getTranscodeImagePath
    path = '/photo/:/transcode/%s/?width=%s&height=%s&url=' % (quote_plus(path), width, height) + quote_plus(path)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py", line 1289, in quote_plus
    return quote(s, safe)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py", line 1282, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xe4'

This fix corrected it, as there were utf8-encoded characters in the path (åäö etc)
