### PR TITLE
Improves SSL certificate generation

### DIFF
--- a/support/OSX/createcert.bash
+++ b/support/OSX/createcert.bash
@@ -5,5 +5,5 @@ cd "$( cd "$( dirname "$0" )" && pwd )"/../..
 
 ## Trailers - hostname is trailers.apple.com
 ## certificate good for 10 years
-openssl req -new -nodes -newkey rsa:2048 -out ./assets/certificates/trailers.pem -keyout ./assets/certificates/trailers.key -x509 -days 3650 -subj "/C=US/CN=trailers.apple.com"
-openssl x509 -in ./assets/certificates/trailers.pem -outform der -out ./assets/certificates/trailers.cer && cat ./assets/certificates/trailers.key >> ./assets/certificates/trailers.pem
+openssl req -new -nodes -newkey rsa:2048 -outform pem -out ./assets/certificates/trailers.cer -keyout ./assets/certificates/trailers.key -x509 -days 3650 -subj "/C=US/CN=trailers.apple.com"
+cat ./assets/certificates/trailers.cer ./assets/certificates/trailers.key >> ./assets/certificates/trailers.pem


### PR DESCRIPTION
Export the certificate in the PEM format instead of the DER format so it does not need to be converted before merging in the pem file.

Implements the proposed change described in #228.

Maybe the wiki should be updated too.

I've tested it and can confirm that everything still works as expected. But maybe it's interesting that somebody else confirms it too.
