### PR TITLE
Add support for "Trailer Posters" Screen Saver

### DIFF
--- a/PlexPosterScreensaver.py
+++ b/PlexPosterScreensaver.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Movie Poster Screensaver functions
+"""
+
+try:
+    import xml.etree.cElementTree as etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+import json
+
+from Debug import *  # dprint(), prettyXML()
+import PlexAPI
+import Settings
+
+
+
+"""
+Plex Media Server: get movie posters, return to aTV as JSON list
+
+parameters:
+    PMS_address
+    path
+    options - dict() of PlexConnect-options as received from aTV, None for no std. X-Plex-Args
+result:
+    aTV screensaver JSON or 'False' in case of error
+"""
+def getScreensaverJSON(options):
+
+    path = '/library/sections/1/recentlyAdded'
+    
+    if not 'PlexConnectUDID' in options:
+        # aTV unidentified, UDID not known
+        return False
+    
+    UDID = options['PlexConnectUDID']
+
+    PlexAPI.discoverPMS(UDID, Settings.CSettings())
+
+    # determine PMS_uuid, PMSBaseURL from IP (PMS_mark)
+    PMS_uuid = PlexAPI.getPMSFromAddress(UDID, '')
+    PMS_baseURL = PlexAPI.getPMSProperty(UDID, PMS_uuid, 'baseURL')
+
+    # retrieve recently added movies from PMS
+    xml = PlexAPI.getXMLFromPMS(PMS_baseURL, path)
+
+    movies = []
+
+    for video in xml.findall('Video'):
+        movies.append({
+            'title': video.get('title'),
+            'thumb': video.get('thumb'),
+        })
+
+    ssPosters = []
+    postersCount = 0
+    for movie in movies:
+        ssPosters.append({
+           "type": "photo",
+           "id": "photo_" + str(postersCount),
+           "assets": [{
+               "width": 406,
+               "height": 600,
+               "src": PMS_baseURL + movie['thumb'],
+           }]
+        })
+        postersCount += 1
+
+    if (len(ssPosters) > options['PlexConnectImagesLength']):
+        JSON = json.dumps(ssPosters[0:options['PlexConnectImagesLength']])
+    else:
+        JSON = json.dumps(ssPosters)
+    
+    dprint(__name__, 1, "====== generated aTV Screensaver JSON ======")
+    dprint(__name__, 1, "{0} [...]", JSON[:255])
+    dprint(__name__, 1, "====== aTV Screensaver JSON finished ======")
+    return(JSON)

--- a/WebServer.py
+++ b/WebServer.py
@@ -28,6 +28,7 @@ import XMLConverter  # XML_PMS2aTV, XML_PlayVideo
 import re
 import Localize
 import Subtitle
+import PlexPosterScreensaver
 
 
 
@@ -177,7 +178,17 @@ class MyHandler(BaseHTTPRequestHandler):
                     self.end_headers()
                     self.wfile.write(JS)
                     return
-                
+
+                # serve "screensaver.json" to aTV
+                if self.path.endswith(".json"):
+                    dprint(__name__, 1, "serving screensaver.json")
+                    json = PlexPosterScreensaver.getScreensaverJSON(options)
+                    self.send_response(200)
+                    self.send_header('Content-type', 'text/json')
+                    self.end_headers()
+                    self.wfile.write(json)
+                    return
+
                 # serve "*.jpg" - thumbnails for old-style mainpage
                 if self.path.endswith(".jpg"):
                     dprint(__name__, 1, "serving *.jpg: "+self.path)

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -279,6 +279,35 @@ function updateSubtitle(time)
 
 
 /*
+ * Trailers Movie poster screensaver handler functions
+ */
+atv.onScreensaverPhotosSelectionEntry = function() {
+    // The collection object is passed to atv.onExecuteQuery as parameters to load Images.
+    // Currently only one collection is able to be passed.
+    var collection = {
+        "id": "trailers-posters",
+        "name": "Trailer Posters",
+        "type": "collection"
+    };
+    atv.setScreensaverPhotosCollection(collection);
+}
+atv.onScreensaverPhotosSelectionExit = function() {
+}
+atv.onExecuteQuery = function(query, callback) {
+  var requestedNumImages = query.length;
+
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", "{{URL(/)}}" + "/ScreenSaver.json?PlexConnectUDID=" + atv.device.udid + "&length=" + requestedNumImages, false);
+  xhr.send();
+
+  var ScreensaverPhotos = JSON.parse(xhr.responseText);
+  if (ScreensaverPhotos.length > requestedNumImages) {
+    ScreensaverPhotos = ScreensaverPhotos.slice(0, requestedNumImages);
+  }
+  callback.success(ScreensaverPhotos);
+}
+
+/*
  *
  * Main app entry point
  *

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -297,7 +297,7 @@ atv.onExecuteQuery = function(query, callback) {
   var requestedNumImages = query.length;
 
   var xhr = new XMLHttpRequest();
-  xhr.open("GET", "{{URL(/)}}" + "/ScreenSaver.json?PlexConnectUDID=" + atv.device.udid + "&length=" + requestedNumImages, false);
+  xhr.open("GET", "{{URL(/)}}" + "/ScreenSaver.json?PlexConnectUDID=" + atv.device.udid + "&PlexConnectImagesLength=" + requestedNumImages, false);
   xhr.send();
 
   var ScreensaverPhotos = JSON.parse(xhr.responseText);


### PR DESCRIPTION
These commits add support for the "Trailer Posters" screen saver option on ATV, as discussed in issue #37.

The application.js file required a large amount of restructuring; for whatever reason the ATV doesn't like it when the application event handlers and non-primitive variables are initialized outside of the application entry point function (onappentry). When the handlers/variables are initialized from the global file scope the request for the screensaver.json file is never made.

The PlexPosterScreensaver generator was just hacked together, as there seems to be very little documentation on how PlexConnect communicates with PMS, and even less on the actual PMS api. Currently it generates an image list for recently added movies, but could be configured to grab images from any server/website that the ATV has network access to.
