### PR TITLE
DNS listen using SO_REUSEADDR to allow binding when a real DNS server is...

### DIFF
--- a/DNSServer.py
+++ b/DNSServer.py
@@ -323,6 +323,7 @@ def Run(cmdPipe, param):
     
     try:
         DNS = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        DNS.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         DNS.settimeout(5.0)
         DNS.bind((cfg_IP_self, int(cfg_Port_DNSServer)))
     except Exception, e:


### PR DESCRIPTION
... hosted on the same machine but on a different IP and insists on listening on 0.0.0.0:53 (with SO_REUSEADDR) - for instance, dnsmasq. Python's HTTPServer already does so for the port 80 and port 443 listeners
