### PR TITLE
ATV doesn't play well with orientation flags in jpeg EXIF.

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1122,18 +1122,12 @@ class CCommandCollection(CCommandHelper):
         photoATVNative = parts[-1].lower() in ['jpg','jpeg','tif','tiff','gif','png']
         dprint(__name__, 2, "photo: ATVNative - {0}", photoATVNative)
         
-        if width=='' and \
-           transcoderAction=='Auto' and \
-           photoATVNative:
-            # direct play
-            res = PlexAPI.getDirectImagePath(key, AuthToken)
-        else:
-            if width=='':
-                width = 1920  # max for HDTV. Relate to aTV version? Increase for KenBurns effect?
-            if height=='':
-                height = 1080  # as above
-            # request transcoding
-            res = PlexAPI.getTranscodeImagePath(key, AuthToken, self.path[srcXML], width, height)
+        if width=='':
+            width = 1920  # max for HDTV. Relate to aTV version? Increase for KenBurns effect?
+        if height=='':
+            height = 1080  # as above
+        # request transcodinng
+        res = PlexAPI.getTranscodeImagePath(key, AuthToken, self.path[srcXML], width, height)
         
         if res.startswith('/'):  # internal full path.
             res = PMS_baseURL + res


### PR DESCRIPTION
A lot of photos in my collection are rotated using EXIF rotation flags which seems not to be supported by ATV. Therefore some pictures show up with wrong orientation.

A simple solution to this problem is to have plex transcode all photos, since it does it well and handles EXIF rotation flawlessly. Don't know how this affects performance on slow plex servers though.
