### PR TITLE
Transcode all EXIF-rotated images since ATV doesn't support it

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1116,6 +1116,10 @@ class CCommandCollection(CCommandHelper):
         
         # transcoder action
         transcoderAction = g_ATVSettings.getSetting(self.ATV_udid, 'phototranscoderaction')
+
+        # image orientation        
+        orientation, leftover, dfltd = self.getKey(src, srcXML, 'Media/Part/orientation')
+        normalOrientation = (not orientation) or orientation=='1'
         
         # aTV native filetypes
         parts = key.rsplit('.',1)
@@ -1124,6 +1128,7 @@ class CCommandCollection(CCommandHelper):
         
         if width=='' and \
            transcoderAction=='Auto' and \
+           normalOrientation and \
            photoATVNative:
             # direct play
             res = PlexAPI.getDirectImagePath(key, AuthToken)


### PR DESCRIPTION
Uses the orientation-info from pms to decide if the image needs to be transcoded or not.
