### PR TITLE
Filtering watched movies from recently added list

### DIFF
--- a/assets/templates/Movie/OnDeck.xml
+++ b/assets/templates/Movie/OnDeck.xml
@@ -5,7 +5,7 @@
 
   <body>
     {{ADDXML(OnDeck::onDeck)}}
-    {{ADDXML(RecentlyAdded::recentlyAdded)}}
+    {{ADDXML(RecentlyAdded::recentlyAdded?unwatched=1)}}
     {{ADDXML(RecentlyReleased::newest)}}
 
     {{VAR(items:NoKey:FALSE)}}  <!--this sets the var to FALSE-->


### PR DESCRIPTION
I doubt this is the best way to implement this feature in the application but adding the GET parameter "unwatched=1" to fetching the XML for the recently added list will make Plex Media Server only return the movies that are currently unwatched. The current version of Plex Home Theater (at least the mac version) only shows movies that have not yet been watched in the recently added list and adding this parameter will replicate that functionality.
