### PR TITLE
Add scanner to fix Home Videos bug.

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -340,7 +340,7 @@ def XML_PMS2aTV(PMS_address, path, options):
         dprint(__name__, 1, "Found Scanner.")
         if cmd.find('Series') != -1: dir = 'TVShow'
         elif cmd.find('Movie') != -1: dir = 'Movie'
-        elif cmd.find('Video') != -1: dir = 'HomeVideo'
+        elif cmd.find('Video') != -1 or cmd.find('Personal_Media') != -1: dir = 'HomeVideo'
         elif cmd.find('Premium_Music') != -1: dir = 'Music'
         elif cmd.find('Photo') != -1: dir = 'Photo'
         elif cmd.find('Music') != -1 or cmd.find('iTunes') != -1: dir ='Music'


### PR DESCRIPTION
This adds the “Personal_Media” scanner and fixes the bug outlined in this thread:
https://forums.plex.tv/index.php/topic/162245-plexconnect-cannot-open-home-movies-library-in-shared-libraries/

The code comes from iBaa