### PR TITLE
Added an outside IP address for dockerized or virtualized environments

### DIFF
--- a/DNSServer.py
+++ b/DNSServer.py
@@ -320,6 +320,7 @@ def Run(cmdPipe, param):
     cfg_IP_self = param['IP_self']
     cfg_Port_DNSServer = param['CSettings'].getSetting('port_dnsserver')
     cfg_IP_DNSMaster = param['CSettings'].getSetting('ip_dnsmaster')
+    cfg_IP_outside = param['IP_outside']
     
     try:
         DNS = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -344,7 +345,7 @@ def Run(cmdPipe, param):
     
     dprint(__name__, 0, "***")
     dprint(__name__, 0, "DNSServer: Serving DNS on {0} port {1}.", cfg_IP_self, cfg_Port_DNSServer)
-    dprint(__name__, 1, "intercept: {0} => {1}", intercept, cfg_IP_self)
+    dprint(__name__, 1, "intercept: {0} => {1}", intercept, cfg_IP_outside)
     dprint(__name__, 1, "restrain: {0} => 127.0.0.1", restrain)
     dprint(__name__, 1, "forward other to higher level DNS: "+cfg_IP_DNSMaster)
     dprint(__name__, 0, "***")
@@ -385,8 +386,8 @@ def Run(cmdPipe, param):
                     paket+=data[12:]                                     # original query
                     paket+='\xc0\x0c'                                    # pointer to domain name/original query
                     paket+='\x00\x01\x00\x01\x00\x00\x00\x3c\x00\x04'    # response type, ttl and resource data length -> 4 bytes
-                    paket+=str.join('',map(lambda x: chr(int(x)), cfg_IP_self.split('.'))) # 4bytes of IP
-                    dprint(__name__, 1, "-> DNS response: "+cfg_IP_self)
+                    paket+=str.join('',map(lambda x: chr(int(x)), cfg_IP_outside.split('.'))) # 4bytes of IP
+                    dprint(__name__, 1, "-> DNS response: "+cfg_IP_outside)
                 
                 elif domain in restrain:
                     dprint(__name__, 1, "***restrain request")
@@ -400,7 +401,7 @@ def Run(cmdPipe, param):
                     paket+='\xc0\x0c'                                    # pointer to domain name/original query
                     paket+='\x00\x01\x00\x01\x00\x00\x00\x3c\x00\x04'    # response type, ttl and resource data length -> 4 bytes
                     paket+='\x7f\x00\x00\x01'  # 4bytes of IP - 127.0.0.1, loopback
-                    dprint(__name__, 1, "-> DNS response: "+cfg_IP_self)
+                    dprint(__name__, 1, "-> DNS response: 127.0.0.1")
                 
                 else:
                     dprint(__name__, 1, "***forward request")

--- a/PlexConnect.py
+++ b/PlexConnect.py
@@ -26,7 +26,7 @@ from Debug import *  # dprint()
 def getIP_self():
     cfg = param['CSettings']
     if cfg.getSetting('enable_plexconnect_autodetect')=='True':
-        # get public ip of machine running PlexConnect
+        # get bind ip of machine running PlexConnect
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(('1.2.3.4', 1000))
         IP = s.getsockname()[0]
@@ -35,6 +35,21 @@ def getIP_self():
         # manual override from "settings.cfg"
         IP = cfg.getSetting('ip_plexconnect')
         dprint('PlexConnect', 0, "IP_self (from settings): "+IP)
+    
+    return IP
+
+def getIP_outside():
+    cfg = param['CSettings']
+    if cfg.getSetting('enable_plexconnect_autodetect_outside')=='True':
+        # get public/outside ip of machine running PlexConnect for clients
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('1.2.3.4', 1000))
+        IP = s.getsockname()[0]
+        dprint('PlexConnect', 0, "IP_outside: "+IP)
+    else:
+        # manual override from "settings.cfg"
+        IP = cfg.getSetting('ip_outside')
+        dprint('PlexConnect', 0, "IP_outside (from settings): "+IP)
     
     return IP
 
@@ -80,6 +95,7 @@ def startup():
     
     # more Settings
     param['IP_self'] = getIP_self()
+    param['IP_outside'] = getIP_outside()
     param['HostToIntercept'] = cfg.getSetting('hosttointercept')
     param['baseURL'] = 'http://'+ param['HostToIntercept']
     

--- a/Settings.py
+++ b/Settings.py
@@ -15,7 +15,8 @@ syntax: 'setting': ('default', 'regex to validate')
 
 PMS: plexgdm, ip_pms, port_pms
 DNS: ip_dnsmaster - IP of Router, ISP's DNS, ... [dflt: google public DNS]
-IP_self: enable_plexconnect_autodetect, ip_plexconnect - manual override for VPN usage
+IP_self: enable_plexconnect_autodetect, ip_plexconnect - manual override for VPN usage (bind address)
+IP_outside: enable_plexconnect_autodetect_outside, ip_outside - manual override for VPN usage (an address presented to a client)
 Intercept: Trailers-trailers.apple.com, WSJ-secure.marketwatch.com, iMovie-www.icloud.com
 HTTP: port_webserver - override when using webserver + forwarding to PlexConnect
 HTTPS: port_ssl, certfile, enable_webserver_ssl - configure SSL portion or webserver
@@ -31,7 +32,9 @@ g_settings = [
     ('prevent_atv_update'           , ('True', '((True)|(False))')),
     \
     ('enable_plexconnect_autodetect', ('True', '((True)|(False))')),
+    ('enable_plexconnect_autodetect_outside', ('True', '((True)|(False))')),
     ('ip_plexconnect'  , ('0.0.0.0', '([0-9]{1,3}\.){3}[0-9]{1,3}')),
+    ('ip_outside'  , ('0.0.0.0', '([0-9]{1,3}\.){3}[0-9]{1,3}')),
     ('hosttointercept' , ('trailers.apple.com', '[a-zA-Z0-9_.-]+')),
     \
     ('port_webserver'  , ('80', '[0-9]{1,5}')),

--- a/support/aTV_jailbreak/Settings_PlexConnect.cfg
+++ b/support/aTV_jailbreak/Settings_PlexConnect.cfg
@@ -1,6 +1,8 @@
 [PlexConnect]
 enable_dnsserver = False
 enable_plexconnect_autodetect = False
+enable_plexconnect_autodetect_outside = False
 ip_plexconnect = 127.0.0.1
+ip_outside = 127.0.0.1
 hosttointercept = localhost
 enable_webserver_ssl = False

--- a/support/aTV_jailbreak/Settings_Trailers.cfg
+++ b/support/aTV_jailbreak/Settings_Trailers.cfg
@@ -1,5 +1,7 @@
 [PlexConnect]
 enable_dnsserver = False
 enable_plexconnect_autodetect = False
+enable_plexconnect_autodetect_outside = False
 ip_plexconnect = 127.0.0.1
+ip_outside = 127.0.0.1
 hosttointercept = localhost


### PR DESCRIPTION
Hello,

for better dockerized or virtualized environments with a private network, there have to be two addresses:
- an address to bind to (you cannot bind to a host address from a private network range)
- an address to present to a DNS client (you have to present a host IP address, to which the request should be made)

For example, I have a dockerized service. The host has IP1, the docker container a private IP2. Inside the container, you cannot bind to IP1. But you have to present the IP1 to a DNS client, so the request is forwarded by Docker to your container based on a port forwarding.

With the current status:
- if I disable **enable_plexconnect_autodetect** and set the **ip_plexconnect** to IP1, it cannot bind.
- if I enable **enable_plexconnect_autodetect**, it binds to IP2, but also presents the IP2 to the DNS client, but IP2 is not reachable from the network.

Best regards,
