### PR TITLE
Add custom DNS bind ip

### DIFF
--- a/DNSServer.py
+++ b/DNSServer.py
@@ -316,8 +316,11 @@ def Run(cmdPipe, param):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
     
     dinit(__name__, param)  # init logging, DNSServer process
+    if param['CSettings'].getSetting('is_custom_dns_bind_ip') == True:
+      cfg_IP_self = param['CSettings'].getSetting('dns_bind_ip')
+    else:
+      cfg_IP_self = param['IP_self']
     
-    cfg_IP_self = param['IP_self']
     cfg_Port_DNSServer = param['CSettings'].getSetting('port_dnsserver')
     cfg_IP_DNSMaster = param['CSettings'].getSetting('ip_dnsmaster')
     

--- a/DNSServer.py
+++ b/DNSServer.py
@@ -316,7 +316,7 @@ def Run(cmdPipe, param):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
     
     dinit(__name__, param)  # init logging, DNSServer process
-    if param['CSettings'].getSetting('is_custom_dns_bind_ip') == True:
+    if param['CSettings'].getSetting('is_custom_dns_bind_ip') == "True":
       cfg_IP_self = param['CSettings'].getSetting('dns_bind_ip')
     else:
       cfg_IP_self = param['IP_self']


### PR DESCRIPTION
If your PlexConnect server have more than one network interface and you would like to bind the DNS server to a different interface than the one your default route is using (Like I do) this will fix it.

Plz merge kthx!
