### PR TITLE
Fix dolby for non-AC3 multi channel audio tracks

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1172,8 +1172,18 @@ class CCommandCollection(CCommandHelper):
                     if Stream.get('profile', '-') == 'high 10' or \
                         int(Stream.get('refFrames','0')) > 8:
                             videoATVNative = False
-                    break
-            
+                            break
+
+		# aTV only supports AC3 Dolby passthrough.  If we're playing a
+		# non-AC3 multi-channel track, transcode the audio to get
+		# surround
+                if Stream.get('streamType','') == '2' and \
+		   Stream.get('selected', '-') == '1' and \
+		   int(Stream.get('channels', '0')) > 2 and \
+		   Stream.get('codec', '-') != 'ac3':
+		    videoATVNative = False
+		    break
+
             dprint(__name__, 2, "video: ATVNative - {0}", videoATVNative)
             
             # quality limits: quality=(resolution, quality, bitrate)


### PR DESCRIPTION
Particularly useful for playing AAC 5.1 tracks on aTV.  Solves this issue:

https://forums.plex.tv/discussion/110680/dolby-digital-with-aac-and-ac3
