### PR TITLE
Adding Plex Cloud Beta Support (Proof of concept)

### DIFF
--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -388,6 +388,12 @@ def getPMSListFromMyPlex(ATV_udid, authtoken):
                 ip = PMSInfo['ip']
                 port = PMSInfo['port']
                 uri = PMSInfo['uri']
+                
+                # Plex Cloud Beta doesn't allow video to work over https. Not sure if this is the best way to do this.
+                if PMSInfo['ip'].endswith('services'):
+                    protocol = 'http'
+                    port = '80'
+                    uri = PMSInfo['uri'].replace('https://', 'http://')
                     
                 if not uuid in g_PMS[ATV_udid]:  # PMS uuid not yet handled, so this must be the fastest response
                     PMSsCnt += 1


### PR DESCRIPTION
Plex Cloud Beta will allow you to navigate sections and download boxart, but it will not load movies. I found information that says it's because it won't work over https. I added this quick fix to check for Plex Cloud Servers  (url ends with services) and then I force the server to http using code.

I have not tested it out fully, I know it works with transcode on, haven't tried direct play or automatic.

As for the code, I'm not sure if there's a better place to do this, maybe in whatever code generates the video play links, or in whatever code adds the servers to the local DB so feel free to reject the pull and do it better, but this works.