### PR TITLE
Support AC3 5.1 (DTS) and rotate photos

### DIFF
--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -475,8 +475,9 @@ def getXArgsDeviceInfo(options={}):
             xargs['X-Plex-Client-Identifier'] = options['PlexConnectUDID']  # UDID for MyPlex device identification
     if 'PlexConnectATVName' in options:
             xargs['X-Plex-Device-Name'] = options['PlexConnectATVName'] # "friendly" name: aTV-Settings->General->Name.
-    xargs['X-Plex-Platform'] = 'tvOS'
-    xargs['X-Plex-Client-Platform'] = 'tvOS'
+    xargs['X-Plex-Platform'] = 'iOS'
+    xargs['X-Plex-Client-Platform'] = 'iOS'
+    xargs['X-Plex-Client-Profile-Extra'] = 'append-transcode-target-audio-codec(type=videoProfile&context=streaming&protocol=hls&audioCodec=ac3,mp3)'
     if 'aTVFirmwareVersion' in options:
         xargs['X-Plex-Platform-Version'] = options['aTVFirmwareVersion']
     xargs['X-Plex-Product'] = 'PlexConnect'

--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -475,8 +475,8 @@ def getXArgsDeviceInfo(options={}):
             xargs['X-Plex-Client-Identifier'] = options['PlexConnectUDID']  # UDID for MyPlex device identification
     if 'PlexConnectATVName' in options:
             xargs['X-Plex-Device-Name'] = options['PlexConnectATVName'] # "friendly" name: aTV-Settings->General->Name.
-    xargs['X-Plex-Platform'] = 'iOS'
-    xargs['X-Plex-Client-Platform'] = 'iOS'
+    xargs['X-Plex-Platform'] = 'tvOS'
+    xargs['X-Plex-Client-Platform'] = 'tvOS'
     if 'aTVFirmwareVersion' in options:
         xargs['X-Plex-Platform-Version'] = options['aTVFirmwareVersion']
     xargs['X-Plex-Product'] = 'PlexConnect'

--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -477,6 +477,7 @@ def getXArgsDeviceInfo(options={}):
             xargs['X-Plex-Device-Name'] = options['PlexConnectATVName'] # "friendly" name: aTV-Settings->General->Name.
     xargs['X-Plex-Platform'] = 'iOS'
     xargs['X-Plex-Client-Platform'] = 'iOS'
+    xargs['X-Plex-Client-Profile-Extra'] = 'append-transcode-target-audio-codec(type=videoProfile&context=streaming&protocol=hls&audioCodec=ac3,mp3)'
     if 'aTVFirmwareVersion' in options:
         xargs['X-Plex-Platform-Version'] = options['aTVFirmwareVersion']
     xargs['X-Plex-Product'] = 'PlexConnect'

--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1021,6 +1021,10 @@ class CCommandCollection(CCommandHelper):
         # transcoder action
         transcoderAction = g_ATVSettings.getSetting(self.ATV_udid, 'phototranscoderaction')
         
+        # image orientation
+	    orientation, leftover, dfltd = self.getKey(src, srcXML, 'Media/Part/orientation')
+	    normalOrientation = (not orientation) or orientation=='1'
+        
         # aTV native filetypes
         parts = key.rsplit('.',1)
         photoATVNative = parts[-1].lower() in ['jpg','jpeg','tif','tiff','gif','png']
@@ -1028,6 +1032,7 @@ class CCommandCollection(CCommandHelper):
         
         if width=='' and \
            transcoderAction=='Auto' and \
+           normalOrientation and \
            photoATVNative:
             # direct play
             res = PlexAPI.getDirectImagePath(key, AuthToken)

--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1075,14 +1075,12 @@ class CCommandCollection(CCommandHelper):
             # transcoder action setting?
             # transcoder bitrate setting [kbps] -  eg. 128, 256, 384, 512?
             maxAudioBitrateCompressed = '320'
-            maxAudioBitrateUncompressed = '2000'  # 2.0Mbps equals smallest available bitrate setting (480p)
-            
+                        
             audioATVNative = \
                 Media.get('audioCodec','-') in ("mp3", "aac", "ac3", "drms") and \
                 int(Media.get('bitrate','0')) <= int(maxAudioBitrateCompressed) \
                 or \
-                Media.get('audioCodec','-') in ("alac", "aiff", "wav") and \
-                int(Media.get('bitrate','0')) <= int(maxAudioBitrateUncompressed)
+                Media.get('audioCodec','-') in ("alac", "aiff", "wav")
             # check Media.get('container') as well - mp3, m4a, ...?
             
             dprint(__name__, 2, "audio: ATVNative - {0}", audioATVNative)


### PR DESCRIPTION
Fixes included:
1) When video transcoding is required AC3 5.1 (DTS) audio is preserved
2) Photos are transcoded only when rotation is needed
3) Lossless audio (alac, aiff, wav) will DirectPlay always (no transcoding needed)