### PR TITLE
Fix dolby digital implementation

### DIFF
--- a/ATVSettings.py
+++ b/ATVSettings.py
@@ -59,6 +59,7 @@ options = { \
     'remotebitrate'     :('720p 3.0Mbps', '720p 4.0Mbps', \
                           '1080p 8.0Mbps', '1080p 10.0Mbps', '1080p 12.0Mbps', '1080p 20.0Mbps', '1080p 40.0Mbps', \
                           '480p 2.0Mbps'), \
+    'dolbydigital'      :('Off', 'On'), \
     'phototranscoderaction'     :('Auto', 'Transcode'), \
     'subtitlerenderer'  :('Auto', 'iOS, PMS', 'PMS'), \
     'subtitlesize'      :('100', '125', '150', '50', '75'), \

--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -477,7 +477,9 @@ def getXArgsDeviceInfo(options={}):
             xargs['X-Plex-Device-Name'] = options['PlexConnectATVName'] # "friendly" name: aTV-Settings->General->Name.
     xargs['X-Plex-Platform'] = 'iOS'
     xargs['X-Plex-Client-Platform'] = 'iOS'
-    xargs['X-Plex-Client-Profile-Extra'] = 'append-transcode-target-audio-codec(type=videoProfile&context=streaming&protocol=hls&audioCodec=ac3,mp3)'
+    if 'DolbyDigital' in options:
+        if options['DolbyDigital']:
+            xargs['X-Plex-Client-Profile-Extra'] = 'append-transcode-target-audio-codec(type=videoProfile&context=streaming&protocol=hls&audioCodec=ac3,mp3)'
     if 'aTVFirmwareVersion' in options:
         xargs['X-Plex-Platform-Version'] = options['aTVFirmwareVersion']
     xargs['X-Plex-Product'] = 'PlexConnect'

--- a/Version.py
+++ b/Version.py
@@ -7,4 +7,4 @@ Version.py
 
 
 # Version string - globally available
-__VERSION__ = '0.5-dev-110616'
+__VERSION__ = '0.5-dev-230417'

--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1160,9 +1160,6 @@ class CCommandCollection(CCommandHelper):
             res = 'VIDEO_ELEMENT_NOT_FOUND'  # not found?
             return res
         
-	# determine if Dolby Digital is active
-	DolbyDigital = g_ATVSettings.getSetting(self.ATV_udid, 'dolbydigital')
-	
         # complete video structure - request transcoding if needed
         Media = Video.find('Media')
         
@@ -1179,7 +1176,10 @@ class CCommandCollection(CCommandHelper):
                 or \
                 Media.get('container','-') in ("mov", "mp4") and \
                 Media.get('videoCodec','-') in ("mpeg4", "h264", "drmi") and \
-                Media.get('audioCodec','-') in ("aac", "ac3", "drms")   # remove AC3 when Dolby Digital is Off
+                Media.get('audioCodec','-') in ("aac", "drms")   # remove AC3 when Dolby Digital is Off
+
+	    # determine if Dolby Digital is active
+	    DolbyDigital = g_ATVSettings.getSetting(self.ATV_udid, 'dolbydigital')
 	    if DolbyDigital=='On':
 		self.options['DolbyDigital'] = True
                 videoATVNative = \

--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1162,8 +1162,6 @@ class CCommandCollection(CCommandHelper):
         
 	# determine if Dolby Digital is active
 	DolbyDigital = g_ATVSettings.getSetting(self.ATV_udid, 'dolbydigital')
-	if DolbyDigital=='On':
-		self.options['DolbyDigital'] = True
 	
         # complete video structure - request transcoding if needed
         Media = Video.find('Media')
@@ -1181,7 +1179,15 @@ class CCommandCollection(CCommandHelper):
                 or \
                 Media.get('container','-') in ("mov", "mp4") and \
                 Media.get('videoCodec','-') in ("mpeg4", "h264", "drmi") and \
-                Media.get('audioCodec','-') in ("aac", "ac3", "drms")
+                Media.get('audioCodec','-') in ("aac", "ac3", "drms")   # remove AC3 when Dolby Digital is Off
+	    if DolbyDigital=='On':
+		self.options['DolbyDigital'] = True
+                videoATVNative = \
+                    Media.get('protocol','-') in ("hls") \
+                    or \
+                    Media.get('container','-') in ("mov", "mp4") and \
+                    Media.get('videoCodec','-') in ("mpeg4", "h264", "drmi") and \
+                    Media.get('audioCodec','-') in ("aac", "ac3", "drms")
             
             for Stream in Media.find('Part').findall('Stream'):
                 if Stream.get('streamType','') == '1' and\

--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1160,6 +1160,11 @@ class CCommandCollection(CCommandHelper):
             res = 'VIDEO_ELEMENT_NOT_FOUND'  # not found?
             return res
         
+	# determine if Dolby Digital is active
+	DolbyDigital = g_ATVSettings.getSetting(self.ATV_udid, 'dolbydigital')
+	if DolbyDigital=='On':
+		self.options['DolbyDigital'] = True
+	
         # complete video structure - request transcoding if needed
         Media = Video.find('Media')
         

--- a/assets/templates/Settings/Main.xml
+++ b/assets/templates/Settings/Main.xml
@@ -149,6 +149,10 @@
                 <label>{{TEXT(Remote Bitrate)}}</label>
                 <rightLabel>{{SETTING(remotebitrate)}}</rightLabel>
               </oneLineMenuItem>
+              <oneLineMenuItem id="DolbyDigital" onSelect="toggleSettings('DolbyDigital', 'Settings_Main')">
+                <label>{{TEXT(Dolby Digital)}}</label>
+                <rightLabel>{{SETTING(dolbydigital)}}</rightLabel>
+              </oneLineMenuItem>
               <oneLineMenuItem id="PhotoTranscoderAction" onSelect="toggleSettings('PhotoTranscoderAction', 'Settings_Main')">
                 <label>{{TEXT(Photo Transcoder Action)}}</label>
                 <rightLabel>{{SETTING(phototranscoderaction)}}</rightLabel>


### PR DESCRIPTION
Previous fix to implement AC3 broke users that do not use Dolby Digital. This new fix creates a new PlexConnect Setting (Dolby Digital) that can be put On for each ATV if, and only if, DD is set to Active in that AppleTV. The default of this new Setting is Off in order to not break users that do not use Dolby Digital.