### PR TITLE
Enable photo playlists

### DIFF
--- a/assets/templates/Playlists/List.xml
+++ b/assets/templates/Playlists/List.xml
@@ -91,6 +91,43 @@
           </menuSection>{{CUT(#items_section::FALSE=CUT|TRUE=)}}  <!--CUT if no section added-->
           </__COPY__>
           
+          <!-- Photo -->
+          <!-- servers -->
+          <__COPY__>  <!--<menuSection>{{COPY}} somehow conflicts with </menuSection>{{CUT}}-->
+          {{COPY(Server:size::0=|1=COPY)}}
+          <menuSection>
+          {{VAR(items_section:NoKey:FALSE)}}  <!--this sets the var to FALSE-->
+            
+            <header>
+              <horizontalDivider alignment="left">
+                <title>{{TEXT(Photo)}}</title>{{CUT(@main/size::0=CUT|1=|1 =CUT)}}
+                <title>{{TEXT(Photo)}} - {{VAL(name)}}{{VAL(local::0= &lt;{{TEXT(remote)}}&gt;|0 =)}}</title>{{CUT(@main/size:CUT:0=CUT|1=CUT|1 =)}}
+              </horizontalDivider>
+            </header>
+            
+            <items>
+              <!-- Playlist -->
+              <oneLineMenuItem id="{{VAL(key)}}"
+                                       onPlay="atv.loadURL('{{URL(key:::PlexConnect=Playlists_Photo)}}')"
+                                       onSelect="atv.loadURL('{{URL(key:::PlexConnect=Playlists_Photo)}}')">
+                                       <!--onSelectHold=""-->
+              {{COPY(Playlist:playlistType::=|photo=COPY|photo =)}}
+              {{VAR(items:NoKey:TRUE)}}  <!--within COPY this sets the var to TRUE-->
+              {{VAR(items_section:NoKey:TRUE)}}
+              
+                <label>{{VAL(title)}}</label>
+                <rightLabel>{{VAL(leafCount)}}</rightLabel>
+                <preview>
+                  <crossFadePreview>
+                    <image>{{IMAGEURL(composite::768)}}</image>
+                  </crossFadePreview>
+                </preview>
+              </oneLineMenuItem>
+              
+            </items>
+          </menuSection>{{CUT(#items_section::FALSE=CUT|TRUE=)}}  <!--CUT if no section added-->
+          </__COPY__>
+          
         </sections>
       </menu>
     </listWithPreview>{{CUT(#items::FALSE=CUT|TRUE=)}}  <!--CUT if no section added-->

--- a/assets/templates/Playlists/Photo.xml
+++ b/assets/templates/Playlists/Photo.xml
@@ -1,0 +1,94 @@
+<atv>
+  <head>
+    <script src="{{URL(:/js/utils.js)}}" />
+  </head>
+  
+  <body>
+    {{VAR(items:NoKey:FALSE)}}  <!--this sets the var to FALSE-->
+    
+    <!-- List (copied from Video with some modifs) -->
+    <listWithPreview id="Playlist_List">
+    {{CUT(size:CUT:0=CUT|1=)}}
+      <header>
+        <simpleHeader>
+          <title>{{VAL(title:{{TEXT(Photo Playlist)}})}}</title>
+        </simpleHeader>
+      </header>
+      
+      <menu>
+        <sections>
+          
+          <menuSection>
+            <items>
+              <!-- shuffle -->
+              <oneLineMenuItem id="shuffle_{{VAL(title)}}"
+                                       onPlay="atv.loadURL('{{URL(key:::PlexConnect=Photo_Directory)}}')"
+                                       onSelect="atv.loadURL('{{URL(key:::PlexConnect=Photo_Directory)}}')">
+                <label>{{TEXT(Shuffle)}}</label>
+                <accessories>
+                  <shuffle/>
+                </accessories>
+                <preview>
+                  <paradePreview inOrder="true">
+                    <image>
+                      {{COPY(Photo:thumb::=COPY)}}
+                      {{IMAGEURL(thumb::768)}}
+                    </image>
+                  </paradePreview>{{CUT(leafCount:CUT:0=CUT|0 =|1=CUT|1 =|2=CUT|2 =|3=CUT|4=CUT|5=CUT|6=)}}
+                  <crossFadePreview>
+                    <image>
+                      {{COPY(Photo:thumb::=COPY)}}
+                      {{IMAGEURL(thumb::768)}}
+                    </image>
+                  </crossFadePreview>{{CUT(leafCount::0=|0 =CUT|1=|1 =CUT|2=|2 =CUT|3=|4=|5=|6=CUT)}}
+                </preview>
+              </oneLineMenuItem>
+            </items>
+          </menuSection>
+          
+          <menuSection>
+            <header>
+              <horizontalDivider alignment="left">
+                <title />
+              </horizontalDivider>
+            </header>
+            
+            <items>
+              <__COPY__>
+              {{COPY(Photo)}}
+              
+              <!-- Photos -->
+              <twoLineEnhancedMenuItem id="{{VAL(key)}}"
+                             onPlay="atv.loadURL('{{URL(key:::PlexConnect=Photo_Directory)}}')"
+                             onSelect="atv.loadURL('{{URL(key:::PlexConnect=Photo_Directory)}}')">
+                             <!--onSelectHold=""-->
+              {{CUT(type::episode=CUT|movie=)}}
+              {{VAR(items:NoKey:TRUE)}}  <!--within COPY this sets the var to TRUE-->
+                <label>{{VAL(title)}}</label>
+                <image>{{IMAGEURL(thumb::384)}}</image>
+                <preview>
+                  <keyedPreview>
+                    <title>{{VAL(title)}}</title>
+                    <summary>{{VAL(summary)}}</summary>
+                    <image>{{IMAGEURL(thumb::768)}}</image>
+                  </keyedPreview>
+                </preview>
+              </twoLineEnhancedMenuItem>
+              
+              </__COPY__>
+            </items>
+          </menuSection>
+          
+        </sections>
+      </menu>
+    </listWithPreview>
+    
+    <!--No Items Available-->
+    <dialog id="com.sample.error-dialog">
+    {{CUT(#items::FALSE=|TRUE=CUT)}}
+      <title>PlexConnect</title>
+      <description>{{TEXT(Photo Playlist: No Items Available)}}</description>
+    </dialog>
+    
+  </body>
+</atv>

--- a/assets/templates/Playlists/TabbedList_Photo.xml
+++ b/assets/templates/Playlists/TabbedList_Photo.xml
@@ -1,0 +1,73 @@
+<atv>
+  <head>
+    <script src="{{URL(:/js/utils.js)}}" />
+  </head>
+  
+  <body>
+    {{VAR(items:NoKey:FALSE)}}  <!--this sets the var to FALSE-->
+    
+    <!-- List -->
+    <listByNavigation id="Playlists_List">
+    {{CUT(size:CUT:0=CUT|1=)}}
+      <header>
+        <tabWithTitle>
+          <title>{{TEXT(Plex Playlists)}}</title>
+        </tabWithTitle>
+      </header>
+
+      <navigation>
+        <navigationItem>
+          <title>Photo</title>
+          <url>{{URL(:/PMS(all)/playlists::PlexConnect=Playlists_TabbedList_Photo)}}</url>
+        </navigationItem>
+        <navigationItem>
+          <title>Audio</title>
+          <url>{{URL(:/PMS(all)/playlists::PlexConnect=Playlists_TabbedList_Audio)}}</url>
+        </navigationItem>
+      </navigation>
+			
+      <menu>
+        <sections>
+          
+          <!-- Photo (copied from Video, with some modifs) -->
+          <!-- servers -->
+          <__COPY__>  <!--<menuSection>{{COPY}} somehow conflicts with </menuSection>{{CUT}}-->
+          {{COPY(Server:size::0=|1=COPY)}}
+          <menuSection>
+          {{VAR(items_section:NoKey:FALSE)}}  <!--this sets the var to FALSE-->
+            
+            <header>
+              <horizontalDivider alignment="left">
+                <title>{{VAL(name)}}{{VAL(local::0= &lt;{{TEXT(remote)}}&gt;|0 =)}}</title>
+              </horizontalDivider>
+            </header>{{CUT(@main/size:CUT:0=CUT|1=CUT|1 =)}}
+            
+            <items>
+              <!-- Playlist -->
+              <oneLineMenuItem id="{{VAL(key)}}"
+                                       onPlay="atv.loadURL('{{URL(key:::PlexConnect=Playlists_Photo)}}')"
+                                       onSelect="atv.loadURL('{{URL(key:::PlexConnect=Playlists_Photo)}}')">
+                                       <!--onSelectHold=""-->
+              {{COPY(Playlist:playlistType::=|photo=COPY|photo =)}}
+              {{VAR(items:NoKey:TRUE)}}  <!--within COPY this sets the var to TRUE-->
+              {{VAR(items_section:NoKey:TRUE)}}
+              
+                <label>{{VAL(title)}}</label>
+                <rightLabel>{{VAL(leafCount)}}</rightLabel>
+                <preview>
+                  <crossFadePreview>
+                    <image>{{IMAGEURL(composite::768)}}</image>
+                  </crossFadePreview>
+                </preview>
+              </oneLineMenuItem>
+              
+            </items>
+          </menuSection>{{CUT(#items_section::FALSE=CUT|TRUE=)}}  <!--CUT if no section added-->
+          </__COPY__>
+          
+        </sections>
+      </menu>{{CUT(#items::FALSE=CUT|TRUE=)}}  <!--CUT if no section added-->
+    </listByNavigation>
+    
+  </body>
+</atv>


### PR DESCRIPTION
Currently photo albums are supported as libraries, but not as playlists. This enhancement enables support of photo playlists.

Photo albums can also contain home videos, PlexConnect does not support these, and playlist support will also have this restriction.