### PR TITLE
Prevent subtitles fetched by Agents from always being burned to video

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -1225,6 +1225,8 @@ class CCommandCollection(CCommandHelper):
                     subtitleId = Stream.get('id','')
                     subtitleKey = Stream.get('key','')
                     subtitleFormat = Stream.get('format','')
+                    if subtitleFormat == '':
+                        subtitleFormat = Stream.get('codec','')
                     break
             
             subtitleIOSNative = \

--- a/assets/templates/HomeVideo/PrePlay.xml
+++ b/assets/templates/HomeVideo/PrePlay.xml
@@ -58,7 +58,7 @@
                   {{VAR(SubtitleStreams:NoKey:{{EVAL({{VAL(#SubtitleStreams)}}+1)}})}}
                   <id>{{VAL(id)}}</id>
                   <language>{{VAL(language:Unknown)}}</language>
-                  <format>{{VAL(format)}}</format>
+                  <format>{{VAL(codec)}}</format>
                   <streamType>{{VAL(streamType)}}</streamType>
                   <selected>{{VAL(selected:0)}}</selected>
                 </stream>

--- a/assets/templates/Movie/PrePlay.xml
+++ b/assets/templates/Movie/PrePlay.xml
@@ -94,7 +94,7 @@
                   {{VAR(SubtitleStreams:NoKey:{{EVAL({{VAL(#SubtitleStreams)}}+1)}})}}
                   <id>{{VAL(id)}}</id>
                   <language>{{VAL(language:Unknown)}}</language>
-                  <format>{{VAL(format)}}</format>
+                  <format>{{VAL(codec)}}</format>
                   <streamType>{{VAL(streamType)}}</streamType>
                   <selected>{{VAL(selected:0)}}</selected>
                 </stream>

--- a/assets/templates/Movie/PrePlay_Fanart.xml
+++ b/assets/templates/Movie/PrePlay_Fanart.xml
@@ -81,7 +81,7 @@
                   {{VAR(SubtitleStreams:NoKey:{{EVAL({{VAL(#SubtitleStreams)}}+1)}})}}
                   <id>{{VAL(id)}}</id>
                   <language>{{VAL(language:Unknown)}}</language>
-                  <format>{{VAL(format)}}</format>
+                  <format>{{VAL(codec)}}</format>
                   <streamType>{{VAL(streamType)}}</streamType>
                   <selected>{{VAL(selected:0)}}</selected>
                 </stream>

--- a/assets/templates/Play/Video.xml
+++ b/assets/templates/Play/Video.xml
@@ -35,7 +35,7 @@
             {{COPY(Media/Part/Stream:streamType::=|3=COPY|3 =)}}
               <subtitleURL> <!-- id="{{VAL(id)}}" key="{{VAL(key)}}" codec="{{VAL(codec)}}"--><!--.srt only -->
               {{CUT(selected:CUT:0=CUT|1=)}}
-                {{URL(key:::PlexConnect=Subtitle&amp;PlexConnectSubtitleFormat={{VAL(format)}})}}
+                {{URL(key:::PlexConnect=Subtitle&amp;PlexConnectSubtitleFormat={{VAL(codec)}})}}
               </subtitleURL>
             </__COPY__>
         </myMetadata>

--- a/assets/templates/TVShow/PrePlay.xml
+++ b/assets/templates/TVShow/PrePlay.xml
@@ -80,7 +80,7 @@
                   {{VAR(SubtitleStreams:NoKey:{{EVAL({{VAL(#SubtitleStreams)}}+1)}})}}
                   <id>{{VAL(id)}}</id>
                   <language>{{VAL(language:Unknown)}}</language>
-                  <format>{{VAL(format)}}</format>
+                  <format>{{VAL(codec)}}</format>
                   <streamType>{{VAL(streamType)}}</streamType>
                   <selected>{{VAL(selected:0)}}</selected>
                 </stream>

--- a/assets/templates/TVShow/PrePlay_Fanart.xml
+++ b/assets/templates/TVShow/PrePlay_Fanart.xml
@@ -74,7 +74,7 @@
                   {{VAR(SubtitleStreams:NoKey:{{EVAL({{VAL(#SubtitleStreams)}}+1)}})}}
                   <id>{{VAL(id)}}</id>
                   <language>{{VAL(language:Unknown)}}</language>
-                  <format>{{VAL(format)}}</format>
+                  <format>{{VAL(codec)}}</format>
                   <streamType>{{VAL(streamType)}}</streamType>
                   <selected>{{VAL(selected:0)}}</selected>
                 </stream>


### PR DESCRIPTION
Hello everyone,
First of all, great work on PlexConnect. It is the only customization available for the un-jailbreak-able ATV3, and I love using it.
I noticed that some of my videos are played using DirectStream, while others are unnecessarily transcoded to burn subtitles in. I have tracked this to a change between sidecar subtitles downloaded manually, which are not burned in, and subtitles fetched automatically by agents, which are burned in. This is due to PMS tagging agent subtitle streams with `'codec=srt'` and not `'format=srt'`.
I've made changes to `XMLConverter.py` to get the `codec` attribute when `format` is unavailable. This should not break anything.
I've made changes to some XML templates but I couldn't figure out how to make a conditional for the XML parsing system, so this might break support for subtitles that do not have the `codec` attribute defined. I did not stumble onto any, but this might require further testing.
Thanks,
Nadav.