### PR TITLE
Fix for profile augmentation

### DIFF
--- a/Debug.py
+++ b/Debug.py
@@ -48,7 +48,7 @@ def dinit(src, param, newlog=False):
         f = open(g_logfile, 'w')
         f.close()
         
-    dprint(src, 0, "started: {0}", time.strftime("%H:%M:%S"))
+    dprint(src, 0, "Started")
 
 
 
@@ -71,7 +71,7 @@ def dprint(src, dlevel, *args):
         # print to file (if filename defined)
         if logToFile:
             f = open(g_logfile, 'a')
-            f.write(time.strftime("%H:%M:%S "))
+            f.write(time.strftime("%b %d,%Y %H:%M:%S "))
             if len(asc_args)==0:
                 f.write(src+":\n")
             elif len(asc_args)==1:
@@ -82,7 +82,7 @@ def dprint(src, dlevel, *args):
         
         # print to terminal window
         if logToTerminal:
-            print(time.strftime("%H:%M:%S")),
+            print(time.strftime("%b %d,%Y %H:%M:%S")),
             if len(asc_args)==0:
                 print src+":"
             elif len(asc_args)==1:

--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -477,9 +477,10 @@ def getXArgsDeviceInfo(options={}):
             xargs['X-Plex-Device-Name'] = options['PlexConnectATVName'] # "friendly" name: aTV-Settings->General->Name.
     xargs['X-Plex-Platform'] = 'iOS'
     xargs['X-Plex-Client-Platform'] = 'iOS'
+    xargs['X-Plex-Client-Profile-Extra'] = 'add-transcode-target(type=videoProfile&context=streaming&protocol=hls&container=mpegts&videoCodec=h264&audioCodec=aac,mp3&replace=true)'
     if 'DolbyDigital' in options:
         if options['DolbyDigital']:
-            xargs['X-Plex-Client-Profile-Extra'] = 'append-transcode-target-audio-codec(type=videoProfile&context=streaming&protocol=hls&audioCodec=ac3,mp3)'
+            xargs['X-Plex-Client-Profile-Extra'] = 'add-transcode-target(type=videoProfile&context=streaming&protocol=hls&container=mpegts&videoCodec=h264&audioCodec=aac,mp3,ac3&replace=true)'
     if 'aTVFirmwareVersion' in options:
         xargs['X-Plex-Platform-Version'] = options['aTVFirmwareVersion']
     xargs['X-Plex-Product'] = 'PlexConnect'

--- a/PlexConnect.py
+++ b/PlexConnect.py
@@ -158,7 +158,7 @@ def shutdown():
         procs[slave].join()
     param['CATVSettings'].saveSettings()
     
-    dprint('PlexConnect', 0, "shutdown")
+    dprint('PlexConnect', 0, "Shutdown")
 
 def cmdShutdown():
     global running

--- a/Version.py
+++ b/Version.py
@@ -7,4 +7,4 @@ Version.py
 
 
 # Version string - globally available
-__VERSION__ = '0.5-dev-230417'
+__VERSION__ = '0.5-dev-161017'


### PR DESCRIPTION
When films only have AC3 tracks that need to be transcoded to AAC, this fix indicates to PMS that audio transcoding is needed. PMS 1.9.4 changed the "decision engine" to support AC3 on recent iPads, which are also using the iOS.xml profile, so PlexConnect needs to explicitly inform that AC3 is not supported, when that is the case (users that AC3 capable players are not affected with this PMS 1.9.4 change)