### PR TITLE
 Add Up Page for docker helthcheck

### DIFF
--- a/WebServer.py
+++ b/WebServer.py
@@ -236,7 +236,15 @@ class MyHandler(BaseHTTPRequestHandler):
                 """
             
             else:
+                """
+                Added Up Page for docker helthcheck
                 self.send_error(403,"Not Serving Client %s" % self.client_address[0])
+                """
+                dprint(__name__, 1, "serving *.html: "+self.path)
+                f = open(sys.path[0] + sep + "assets/up.html")
+                self.sendResponse(f.read(), 'text/html', False)
+                f.close()
+
         except IOError:
             dprint(__name__, 0, 'File Not Found:\n{0}', traceback.format_exc())
             self.send_error(404,"File Not Found: %s" % self.path)

--- a/assets/up.html
+++ b/assets/up.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="description" content="Plexconnect">
+	<title>Plexconnect UP</title>
+</head>
+<body>
+<h1>UP</h1>
+</body>
+</html>


### PR DESCRIPTION
Add a hosted webpage to plexconnect can help for other apps and docker to check if plexconnect is up.
But also can be added on for other functionality.