### PR TITLE
take optional --config_path argument to move cfg files to a subfolder

### DIFF
--- a/ATVSettings.py
+++ b/ATVSettings.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 import sys
-from os import sep
+from os import sep, makedirs
+from os.path import isdir
 import ConfigParser
 import fnmatch
 
@@ -83,9 +84,10 @@ options = { \
 
 
 class CATVSettings():
-    def __init__(self):
+    def __init__(self, path):
         dprint(__name__, 1, "init class CATVSettings")
         self.cfg = None
+        self.path = path
         self.loadSettings()
     
     
@@ -109,7 +111,15 @@ class CATVSettings():
         f.close()
     
     def getSettingsFile(self):
-        return sys.path[0] + sep + "ATVSettings.cfg"
+        if self.path.startswith('.'):
+            # relative to current path
+            directory = sys.path[0] + sep + self.path
+        else:
+            # absolute path
+            directory = self.path
+        if not isdir(directory):
+            makedirs(directory)
+        return directory + "/ATVSettings.cfg"
     
     def checkSection(self, UDID):
         # check for existing UDID section

--- a/PlexConnect.py
+++ b/PlexConnect.py
@@ -14,6 +14,7 @@ import socket
 from multiprocessing import Process, Pipe
 from multiprocessing.managers import BaseManager
 import signal, errno
+import argparse
 
 from Version import __VERSION__
 import DNSServer, WebServer
@@ -22,6 +23,7 @@ from PILBackgrounds import isPILinstalled
 from Debug import *  # dprint()
 
 
+CONFIG_PATH = '.'
 
 def getIP_self():
     cfg = param['CSettings']
@@ -60,7 +62,7 @@ def startup():
     global running
     
     # Settings
-    cfg = Settings.CSettings()
+    cfg = Settings.CSettings(CONFIG_PATH)
     param['CSettings'] = cfg
     
     # Logfile
@@ -89,7 +91,7 @@ def startup():
     proxy = BaseManager()
     proxy.register('ATVSettings', ATVSettings.CATVSettings)
     proxy.start(initProxy)
-    param['CATVSettings'] = proxy.ATVSettings()
+    param['CATVSettings'] = proxy.ATVSettings(CONFIG_PATH)
     
     running = True
     
@@ -181,6 +183,12 @@ def sighandler_shutdown(signum, frame):
 if __name__=="__main__":
     signal.signal(signal.SIGINT, sighandler_shutdown)
     signal.signal(signal.SIGTERM, sighandler_shutdown)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config_path', metavar='<config_path>', required=False,
+                        help='path of folder containing config files, relative to PlexConnect.py')
+    args = parser.parse_args()
+    if args.config_path:
+        CONFIG_PATH = args.config_path
     
     dprint('PlexConnect', 0, "***")
     dprint('PlexConnect', 0, "PlexConnect")

--- a/Settings.py
+++ b/Settings.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 import sys
-from os import sep
+from os import sep, makedirs
+from os.path import isdir
 import ConfigParser
 import re
 
@@ -57,11 +58,12 @@ g_settings = [
 
 
 class CSettings():
-    def __init__(self):
+    def __init__(self, path):
         dprint(__name__, 1, "init class CSettings")
         self.cfg = ConfigParser.SafeConfigParser()
         self.section = 'PlexConnect'
-        
+        self.path = path
+
         # set option for fixed ordering
         self.cfg.add_section(self.section)
         for (opt, (dflt, vldt)) in g_settings:
@@ -84,7 +86,15 @@ class CSettings():
         f.close()
     
     def getSettingsFile(self):
-        return sys.path[0] + sep + "Settings.cfg"
+        if self.path.startswith('.'):
+            # relative to current path
+            directory = sys.path[0] + sep + self.path
+        else:
+            # absolute path
+            directory = self.path
+        if not isdir(directory):
+            makedirs(directory)
+        return directory + "/Settings.cfg"
     
     def checkSection(self):
         modify = False


### PR DESCRIPTION
if you invoke `python2 ./PlexConnect.py` as usual, nothing changes.
if you invoke `python2 ./PlexConnect.py --config_path=./config`, config files will be read and written from `./config`.  This will make dockerizing PlexConnect easier.