### PR TITLE
Fix overwriting path in getSubtitleJSON

### DIFF
--- a/Subtitle.py
+++ b/Subtitle.py
@@ -34,7 +34,7 @@ def getSubtitleJSON(PMS_address, path, options):
         if UDID:
             options['PlexConnectUDID'] = UDID
     """
-    path = path + '?' if not '?' in path else '&'
+    path = path + ('?' if not '?' in path else '&')
     path = path + 'encoding=utf-8'
     
     if not 'PlexConnectUDID' in options:


### PR DESCRIPTION
`path = path + '?' if not '?' in path else '&'` is equivalent to `path = (path + '?') if not '?' in path else '&'`, which overwrites path, so the else case ends up as `path = '&'`.

With some debugging in the log, before the change I see:
```
Sep 12 13:41:40 dill python2[13321]: Sep 12,2020 13:41:40 Subtitle: XXX sub path: '/library/metadata/2989?includeExtras=1'
Sep 12 13:41:40 dill python2[13321]: Sep 12,2020 13:41:40 Subtitle: XXX sub path: '&encoding=utf-8'
Sep 12 13:41:40 dill python2[13321]: Sep 12,2020 13:41:40 Subtitle: subtitle URL: http://192.168.1.28:32400&encoding=utf-8
```

And after:
```
Sep 12 13:44:32 dill python2[13800]: Sep 12,2020 13:44:32 Subtitle: XXX sub path: '/library/metadata/2989?includeExtras=1'
Sep 12 13:44:32 dill python2[13800]: Sep 12,2020 13:44:32 Subtitle: XXX sub path: '/library/metadata/2989?includeExtras=1&encoding=utf-8'
Sep 12 13:44:32 dill python2[13800]: Sep 12,2020 13:44:32 Subtitle: subtitle URL: http://192.168.1.28:32400/library/metadata/2989?includeExtras=1&encoding=utf-8
```