### PR TITLE
XMLConverter: fix: youtube/get_video_info 404s without &html5=1 these days

### DIFF
--- a/XMLConverter.py
+++ b/XMLConverter.py
@@ -217,7 +217,7 @@ def XML_PMS2aTV(PMS_address, path, options):
     
     elif cmd=='PlayTrailer':
         trailerID = options['PlexConnectTrailerID']
-        info = urllib2.urlopen("https://youtube.com/get_video_info?video_id=" + trailerID).read()
+        info = urllib2.urlopen("https://youtube.com/get_video_info?html5=1&video_id=" + trailerID).read()
         parsed = urlparse.parse_qs(info)
         
         key = 'player_response'


### PR DESCRIPTION
See https://github.com/ytdl-org/youtube-dl/commit/24297a42efc52862cb9510d32b28efd7faf49af6 for equivalent hackfix.