### PR TITLE
FIxed logout now works again

### DIFF
--- a/PlexAPI.py
+++ b/PlexAPI.py
@@ -725,13 +725,13 @@ def MyPlexSignIn(username, password, options):
 def MyPlexSignOut(authtoken):
     # MyPlex web address
     MyPlexHost = 'plex.tv'
-    MyPlexSignOutPath = '/users/sign_out.xml'
+    MyPlexSignOutPath = '/api/v2/users/signout'
     MyPlexURL = 'http://' + MyPlexHost + MyPlexSignOutPath
     
     # create POST request
     xargs = { 'X-Plex-Token': authtoken }
     request = urllib2.Request(MyPlexURL, None, xargs)
-    request.get_method = lambda: 'POST'  # turn into 'POST' - done automatically with data!=None. But we don't have data.
+    request.get_method = lambda: 'DELETE'  # turn into 'DELETE' - done automatically with data!=None. But we don't have data.
     
     response = urllib2.urlopen(request).read()
     


### PR DESCRIPTION
Logout via ATV3 against plex.tv API was broken.  Severe problem because a ATV3 device can get stuck with a token that is no longer valid.  Even factory resetting the ATV3 device will not clear out the saved PlexConnect Plex.tv token.  The only way to clear it is by logging out.  With logging out broken, the ATV3 device is unusable for PlexConnect.  With this fix, the issue is solved.

Debugged locally on 3 separate ATV devices, reproduced, found endpoint no longer existed.  Created forum post at plex.tv https://forums.plex.tv/t/sign-out-plex-tv-api-endpoint-changed-plexconnect-erroring-on-sign-out-attempt-now/835439/2 and implemented this change's solution based on forum post.  Tested on 3 ATV3 devices and they now work.  Before fixing the error was generating the following log output: Traceback (most recent call last):
  File "/PlexConnect/WebServer.py", line 248, in do_GET
    XML = XMLConverter.XML_PMS2aTV(PMSaddress, self.path + query, options)
  File "/PlexConnect/XMLConverter.py", line 265, in XML_PMS2aTV
    PlexAPI.MyPlexSignOut(auth_token)
  File "/PlexConnect/PlexAPI.py", line 736, in MyPlexSignOut
    response = urllib2.urlopen(request).read()
  File "/usr/local/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/usr/local/lib/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/lib/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 556, in http_error_default
  File "/PlexConnect/WebServer.py", line 248, in do_GET
    XML = XMLConverter.XML_PMS2aTV(PMSaddress, self.path + query, options)
  File "/PlexConnect/XMLConverter.py", line 265, in XML_PMS2aTV
    PlexAPI.MyPlexSignOut(auth_token)
  File "/PlexConnect/PlexAPI.py", line 736, in MyPlexSignOut
    response = urllib2.urlopen(request).read()
  File "/usr/local/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/usr/local/lib/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/lib/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 556, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
HTTPError: HTTP Error 308: Permanent Redirect

Now the log is clean and logging out can occur.

ps. make sure to log in to your PlexConnect service CLI and to test the changes run a
``` service plexconnect restart ```